### PR TITLE
Bug fixes and a few new features

### DIFF
--- a/SHSPhoneComponents/SHSPhoneLogic.m
+++ b/SHSPhoneComponents/SHSPhoneLogic.m
@@ -50,14 +50,12 @@
 
 +(BOOL)logicTextField:(SHSPhoneTextField *)textField shouldChangeCharactersInRange:(NSRange)range replacementString:(NSString *)string
 {
-    NSString *newString;
-    BOOL isDeleting = (string.length == 0);
-    NSInteger caretPosition = [self pushCaretPosition:textField range:range];
+    if (textField.formatter.prefix.length && range.location < textField.formatter.prefix.length) {
+        return NO;
+    }
     
-    if (isDeleting)
-        newString = [SHSPhoneNumberFormatter formattedRemove:textField.text AtIndex:range];
-    else
-        newString = [textField.text stringByReplacingCharactersInRange:range withString:string];
+    NSInteger caretPosition = [self pushCaretPosition:textField range:range];    
+    NSString *newString = [textField.text stringByReplacingCharactersInRange:range withString:string];
     
     [self applyFormat:textField forText:newString];
     [self popCaretPosition:textField range:range caretPosition:caretPosition];

--- a/SHSPhoneComponents/SHSPhoneNumberFormatter+UserConfig.h
+++ b/SHSPhoneComponents/SHSPhoneNumberFormatter+UserConfig.h
@@ -14,6 +14,12 @@
 /**
  Remove all patterns and apply clear format style.
  Default format is @"#############", imagePath is nil.
+ */
+-(void) resetDefaultFormat;
+
+/**
+ Remove all patterns and apply clear format style.
+ Default format is @"#############", imagePath is nil.
 */
 -(void) resetFormats;
 
@@ -44,5 +50,14 @@
  Example: pattern is "+# (###) ###-##-##", regexp is "^375\\d*$"
 */
 -(void) addOutputPattern:(NSString *)pattern forRegExp:(NSString *)regexp;
+
+/**
+ Patters array keep references to dictionaries each with individual patterns configuration. Each pattern dictionary should contain key "format" with format representation string, key for regular expression named "regexp" with string value and optionally "imagePath" key with image name string
+ 
+ All number matched your regexp will formatted with your style and image
+ Symbol '#' assumes all digits.
+ Example: format is "+# (###) ###-##-##", imagePath is "flag_ru", regexp is "^375\\d*$"
+ */
+-(void) setOutputPatternsFromArray:(NSArray *)patterns;
 
 @end

--- a/SHSPhoneComponents/SHSPhoneNumberFormatter+UserConfig.m
+++ b/SHSPhoneComponents/SHSPhoneNumberFormatter+UserConfig.m
@@ -12,17 +12,40 @@
 
 #pragma mark Predefined Configs
 
+-(NSDictionary *) defaultPattern
+{
+    return @{ @"format": @"#############", @"image": [NSNull null]};
+}
+
 -(NSDictionary *) resetConfig
 {
-    return @{ @"default": @{ @"format": @"#############", @"image": [NSNull null]} };
+    return @{ @"default": [self defaultPattern] };
 }
 
 #pragma mark -
 #pragma mark Format Setters
 
+-(void) resetDefaultFormat
+{
+    if (config) {
+        [config setObject:[self defaultPattern] forKey:@"default"];
+    }
+    else {
+        config = [[NSMutableDictionary alloc] initWithDictionary:@{ @"default": [self defaultPattern] }];
+    }
+}
+
 -(void) resetFormats
 {
-    config = [[NSMutableDictionary alloc]initWithDictionary:[self resetConfig]];
+    NSDictionary * defaultPattern = [config objectForKey:@"default"];
+    
+    if (defaultPattern) {
+        // Don't reset default pattern if exists
+        config = [[NSMutableDictionary alloc]initWithDictionary:@{ @"default": defaultPattern }];
+    }
+    else {
+        config = [[NSMutableDictionary alloc]initWithDictionary:[self resetConfig]];
+    }
 }
 
 -(void) setDefaultOutputPattern:(NSString *)pattern imagePath:(NSString *)imagePath
@@ -52,6 +75,20 @@
 -(void) addOutputPattern:(NSString *)pattern forRegExp:(NSString *)regexp
 {
     [config setObject:@{@"format": pattern, @"image": [NSNull null]} forKey:regexp];
+}
+
+-(void) setOutputPatternsFromArray:(NSArray *)patterns
+{
+    if (patterns) {
+        for (NSDictionary * pattern in patterns) {
+            NSString * format = pattern[@"format"];
+            NSString * regexp = pattern[@"regexp"];
+            
+            if (format && regexp) {
+                [self addOutputPattern:format forRegExp:regexp imagePath:pattern[@"imagePath"]];
+            }
+        }
+    }
 }
 
 #pragma mark -

--- a/SHSPhoneComponents/SHSPhoneNumberFormatter.m
+++ b/SHSPhoneComponents/SHSPhoneNumberFormatter.m
@@ -196,8 +196,10 @@
 
 -(void) setPrefix:(NSString *)prefix
 {
+    // Change only prefix if it was set before keeping phone number as it is
+    NSString * phoneNumber = self.textField.phoneNumberWithoutPrefix;
     _prefix = (prefix ? prefix : @"");
-    [SHSPhoneLogic applyFormat:self.textField forText:[self.textField text]];
+    [SHSPhoneLogic applyFormat:self.textField forText:[_prefix stringByAppendingString:phoneNumber ?: @""]];
 }
 
 @end

--- a/SHSPhoneComponents/SHSPhoneTextField.h
+++ b/SHSPhoneComponents/SHSPhoneTextField.h
@@ -37,6 +37,11 @@
 -(NSString *) phoneNumber;
 
 /**
+ Return phone number without format and prefix
+ */
+-(NSString *) phoneNumberWithoutPrefix;
+
+/**
  Block will be called when text changed
  */
 typedef void (^SHSTextBlock)(UITextField *textField);

--- a/SHSPhoneComponents/SHSPhoneTextField.m
+++ b/SHSPhoneComponents/SHSPhoneTextField.m
@@ -66,6 +66,11 @@
     return [self.formatter digitOnlyString:self.text];
 }
 
+-(NSString *)phoneNumberWithoutPrefix
+{
+    return [self.formatter digitOnlyString:[self.text stringByReplacingOccurrencesOfString:self.formatter.prefix withString:@""]];
+}
+
 @end
 
 


### PR DESCRIPTION
- SHSPhoneLogic bugfix: when user try to delete prefix (when it was set) with empty phone number, textfield adds prefix digits (without last digit) to phone number. This happens when prefix contains more then 1 digit.
- SHSNumberFormatter: added method to read formats from predefined configuration array, It helps to read configuration when using .plist to store phone formats.
- SHSNumberFormatter: resetFormats preserves default pattern from changing, so you don't need to set custom default format every time you want to reset added formats. To reset default format user should call resetDefaultFormat or cnage it via setDefaultOutputPattern.
- SHSPhoneTextField: added method to return phone number without format and prefix
