### PR TITLE
Sends ValueChanged event when text changes

### DIFF
--- a/SHSPhoneComponents/Library/SHSPhoneLogic.m
+++ b/SHSPhoneComponents/Library/SHSPhoneLogic.m
@@ -44,6 +44,8 @@
     NSDictionary *result = [textField.formatter valuesForString:text];
     textField.text = result[@"text"];
     
+    [textField sendActionsForControlEvents:UIControlEventValueChanged];
+
     if ( textField.formatter.canAffectLeftViewByFormatter )
         [self updateLeftImageView:textField imagePath:result[@"image"]];
 }


### PR DESCRIPTION
Adds the capability to use [phoneTextField addTarget:someTarget action:@selector(someSelector:) forControlEvents:UIControlEventValueChanged];
